### PR TITLE
refactor(genetics): apply review findings to GA + map display

### DIFF
--- a/apps/panacee-genetics/makefile
+++ b/apps/panacee-genetics/makefile
@@ -1,18 +1,20 @@
-CC = cc
+CC          = cc
 CFLAGS = -Wall -ansi -g
-NAME = panacee
+NAME        = panacee
 NAME_NO_MLV = panacee-no-mlv
 
-SRC_DIR = src
-OBJ_DIR = bin/full
+SRC_DIR        = src
+OBJ_DIR        = bin/full
 OBJ_DIR_NO_MLV = bin/no-mlv
+RESULTS_DIR    = $(SRC_DIR)/results
 
-SRC = $(shell find $(SRC_DIR) -type f -name "*.c")
-OBJ = $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRC))
+SRC        = $(shell find $(SRC_DIR) -type f -name "*.c")
+OBJ        = $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRC))
 OBJ_NO_MLV = $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR_NO_MLV)/%.o,$(SRC))
 
 all: $(NAME)
 
+# ---- main MLV build ----
 $(NAME): CFLAGS += -DUSE_MLV
 $(NAME): $(OBJ)
 	$(CC) $(OBJ) -o $(NAME) -lMLV -lm
@@ -21,6 +23,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
+# ---- headless (no MLV) build ----
 no-mlv: $(NAME_NO_MLV)
 
 $(NAME_NO_MLV): $(OBJ_NO_MLV)
@@ -30,15 +33,19 @@ $(OBJ_DIR_NO_MLV)/%.o: $(SRC_DIR)/%.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-run: $(NAME)
+# ---- runners ----
+$(RESULTS_DIR):
+	@mkdir -p $(RESULTS_DIR)
+
+run: $(NAME) $(RESULTS_DIR)
 	./$(NAME)
 
-run-no-mlv: $(NAME_NO_MLV)
+run-no-mlv: $(NAME_NO_MLV) $(RESULTS_DIR)
 	./$(NAME_NO_MLV)
 
+# ---- cleanup ----
 clean:
-	-find $(OBJ_DIR) -mindepth 1 -delete 2>/dev/null; true
-	-find $(OBJ_DIR_NO_MLV) -mindepth 1 -delete 2>/dev/null; true
+	rm -rf $(OBJ_DIR) $(OBJ_DIR_NO_MLV)
 
 fclean: clean
 	rm -f $(NAME) $(NAME_NO_MLV)

--- a/apps/panacee-genetics/src/domain/fitness/fitness.c
+++ b/apps/panacee-genetics/src/domain/fitness/fitness.c
@@ -6,6 +6,6 @@ double calculate_fitness_score(int total_inhabitants,
                                int hospitals_count,
                                int uhc_count)
 {
-    return (double)total_inhabitants - distant_residents - (double)PENALITY_HOSPITAL * hospitals_count + (double)BONUS_UHC * uhc_count;
+    return (double)total_inhabitants - distant_residents - (double)PENALTY_HOSPITAL * hospitals_count + (double)BONUS_UHC * uhc_count;
 }
 

--- a/apps/panacee-genetics/src/domain/individual/individual.c
+++ b/apps/panacee-genetics/src/domain/individual/individual.c
@@ -341,7 +341,7 @@ void compute_beds(Individual *ind, const Town *towns, int town_count,
     for (i = 0; i < town_count; i++)
     {
         nearest_hospital[i] = -1;
-        nearest_dist[i] = 1e18;
+        nearest_dist[i] = INFINITY_KM;
     }
 
     for (h = 0; h < ind->size; h++)

--- a/apps/panacee-genetics/src/domain/individual/individual.c
+++ b/apps/panacee-genetics/src/domain/individual/individual.c
@@ -332,39 +332,19 @@ void compute_beds(Individual *ind, const Town *towns, int town_count,
                   const int *insee_to_idx, int **coverage,
                   const int *coverage_size)
 {
-    int i, k, h;
+    int i, h;
     int *inhabitants_per_hospital = calloc(ind->size, sizeof(int));
-    /* nearest_hospital[t] = index in ind->hospitals of the closest hospital covering town t */
     int *nearest_hospital = malloc(town_count * sizeof(int));
-    double *nearest_dist = malloc(town_count * sizeof(double));
 
-    for (i = 0; i < town_count; i++)
-    {
-        nearest_hospital[i] = -1;
-        nearest_dist[i] = INFINITY_KM;
-    }
-
-    for (h = 0; h < ind->size; h++)
-    {
-        int j = insee_to_idx[ind->hospitals[h].insee];
-        if (j < 0)
-            continue;
-        for (k = 0; k < coverage_size[j]; k++)
-        {
-            int t = coverage[j][k];
-            double d = haversine_km(towns[j].latitude, towns[j].longitude,
-                                    towns[t].latitude, towns[t].longitude);
-            if (d < nearest_dist[t])
-            {
-                nearest_dist[t] = d;
-                nearest_hospital[t] = h;
-            }
-        }
-    }
+    nearest_hospital_per_town(ind->hospitals, ind->size,
+                              towns, town_count,
+                              insee_to_idx, coverage, coverage_size,
+                              nearest_hospital, NULL);
 
     for (i = 0; i < town_count; i++)
         if (nearest_hospital[i] >= 0)
-            inhabitants_per_hospital[nearest_hospital[i]] += towns[i].inhabitants_count;
+            inhabitants_per_hospital[nearest_hospital[i]] +=
+                towns[i].inhabitants_count;
 
     for (h = 0; h < ind->size; h++)
         ind->hospitals[h].beds_count =
@@ -372,6 +352,5 @@ void compute_beds(Individual *ind, const Town *towns, int town_count,
 
     free(inhabitants_per_hospital);
     free(nearest_hospital);
-    free(nearest_dist);
 }
 

--- a/apps/panacee-genetics/src/domain/individual/individual.c
+++ b/apps/panacee-genetics/src/domain/individual/individual.c
@@ -167,7 +167,7 @@ Individual crossover(const Individual *a, const Individual *b, int town_count)
     int i;
     Individual child;
     /* INSEE codes are at most 5 digits (max 99999) */
-    char *present = calloc(100000, 1);
+    char *present = calloc(INSEE_MAX, 1);
     Hospital *pool = malloc((a->size + b->size) * sizeof(Hospital));
     int pool_n = 0;
     int target_size;

--- a/apps/panacee-genetics/src/domain/individual/individual.c
+++ b/apps/panacee-genetics/src/domain/individual/individual.c
@@ -23,7 +23,7 @@ void evaluate(Individual *ind, Town *towns, int town_count,
             continue;
         for (k = 0; k < coverage_size[j]; k++)
             covered[coverage[j][k]] = 1;
-        if (towns[j].inhabitants_count > TRESHOLD_UHC)
+        if (towns[j].inhabitants_count > THRESHOLD_UHC)
             uhc_count++;
     }
 

--- a/apps/panacee-genetics/src/domain/individual/individual.c
+++ b/apps/panacee-genetics/src/domain/individual/individual.c
@@ -1,5 +1,4 @@
 #include "../../genetic.h"
-#include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/apps/panacee-genetics/src/domain/individual/individual.c
+++ b/apps/panacee-genetics/src/domain/individual/individual.c
@@ -5,7 +5,7 @@
 
 /* Evaluate an individual using precomputed coverage lists.
    coverage[j] = array of town indices within RADIUS_HOSPITAL_KM of town j. */
-void evaluate(Individual *ind, Town *towns, int town_count,
+void evaluate(Individual *ind, const Town *towns, int town_count,
               const int *insee_to_idx, int **coverage, const int *coverage_size,
               int total_inhabitants)
 {
@@ -51,7 +51,7 @@ void evaluate(Individual *ind, Town *towns, int town_count,
 
 /* Random individual: pick k random distinct towns as hospitals.
    k varies in [ratio/2 .. ratio*2] to seed diversity in the population. */
-Individual create_individual_random(Town *towns, int town_count)
+Individual create_individual_random(const Town *towns, int town_count)
 {
     Individual ind;
     int i, k;
@@ -82,7 +82,7 @@ Individual create_individual_random(Town *towns, int town_count)
 /* Greedy stochastic individual: at each step, pick randomly from towns whose
    score (uncovered inhabitants they would cover) is >= 90% of the current best.
    Scores are updated lazily — O(town_count * avg_coverage) total. */
-Individual create_individual_greedy(Town *towns, int town_count,
+Individual create_individual_greedy(const Town *towns, int town_count,
                                     int **coverage, const int *coverage_size)
 {
     Individual ind;
@@ -255,8 +255,9 @@ void remove_redundant(Individual *ind, int **coverage, const int *coverage_size,
 }
 
 /* Random variation for an individual */
-void mutate(Individual *ind, Town *towns, int town_count, double mutation_rate,
-            int **coverage, const int *coverage_size, const int *insee_to_idx)
+void mutate(Individual *ind, const Town *towns, int town_count,
+            double mutation_rate, int **coverage, const int *coverage_size,
+            const int *insee_to_idx)
 {
     int op, idx, new_idx, i, k;
 
@@ -327,8 +328,9 @@ void mutate(Individual *ind, Town *towns, int town_count, double mutation_rate,
 /* Compute beds_count for each hospital in the result.
    Each covered town is assigned to its nearest hospital.
    beds_count = floor(BEDS_PER_INHABITANT / 1000 * assigned_inhabitants).*/
-void compute_beds(Individual *ind, Town *towns, int town_count,
-                  const int *insee_to_idx, int **coverage, const int *coverage_size)
+void compute_beds(Individual *ind, const Town *towns, int town_count,
+                  const int *insee_to_idx, int **coverage,
+                  const int *coverage_size)
 {
     int i, k, h;
     int *inhabitants_per_hospital = calloc(ind->size, sizeof(int));

--- a/apps/panacee-genetics/src/domain/individual/individual.h
+++ b/apps/panacee-genetics/src/domain/individual/individual.h
@@ -12,13 +12,21 @@ typedef struct
     Fitness fitness;
 } Individual;
 
-Individual create_individual_random(Town *towns, int town_count);
-Individual create_individual_greedy(Town *towns, int town_count, int **coverage, const int *coverage_size);
+Individual create_individual_random(const Town *towns, int town_count);
+Individual create_individual_greedy(const Town *towns, int town_count,
+                                    int **coverage, const int *coverage_size);
 void free_individual(Individual *ind);
 Individual crossover(const Individual *a, const Individual *b, int town_count);
-void remove_redundant(Individual *ind, int **coverage, const int *coverage_size, const int *insee_to_idx, int town_count);
-void mutate(Individual *ind, Town *towns, int town_count, double mutation_rate, int **coverage, const int *coverage_size, const int *insee_to_idx);
-void compute_beds(Individual *ind, Town *towns, int town_count, const int *insee_to_idx, int **coverage, const int *coverage_size);
-void evaluate(Individual *ind, Town *towns, int town_count, const int *insee_to_idx, int **coverage, const int *coverage_size, int total_inhabitants);
+void remove_redundant(Individual *ind, int **coverage, const int *coverage_size,
+                      const int *insee_to_idx, int town_count);
+void mutate(Individual *ind, const Town *towns, int town_count,
+            double mutation_rate, int **coverage, const int *coverage_size,
+            const int *insee_to_idx);
+void compute_beds(Individual *ind, const Town *towns, int town_count,
+                  const int *insee_to_idx, int **coverage,
+                  const int *coverage_size);
+void evaluate(Individual *ind, const Town *towns, int town_count,
+              const int *insee_to_idx, int **coverage,
+              const int *coverage_size, int total_inhabitants);
 
 #endif

--- a/apps/panacee-genetics/src/domain/population/population.c
+++ b/apps/panacee-genetics/src/domain/population/population.c
@@ -3,7 +3,7 @@
 
 /* Initialize population: 80% greedy individuals for a strong start,
    20% random for diversity. */
-Population init_population(Town *towns, int town_count,
+Population init_population(const Town *towns, int town_count,
                            int **coverage, const int *coverage_size)
 {
     int i;
@@ -56,7 +56,7 @@ Individual best_individual(const Population *pop)
 }
 
 /* Evaluate all individuals in a population */
-void evaluate_population(Population *pop, Town *towns, int town_count,
+void evaluate_population(Population *pop, const Town *towns, int town_count,
                          const int *insee_to_idx, int **coverage,
                          const int *coverage_size, int total_inhabitants)
 {

--- a/apps/panacee-genetics/src/domain/population/population.h
+++ b/apps/panacee-genetics/src/domain/population/population.h
@@ -9,10 +9,13 @@ typedef struct
     int         size;
 } Population;
 
-Population init_population(Town *towns, int town_count, int **coverage, const int *coverage_size);
+Population init_population(const Town *towns, int town_count,
+                           int **coverage, const int *coverage_size);
 void free_population(Population *pop);
 Individual tournament_select(const Population *pop);
 Individual best_individual(const Population *pop);
-void evaluate_population(Population *pop, Town *towns, int town_count, const int *insee_to_idx, int **coverage, const int *coverage_size, int total_inhabitants);
+void evaluate_population(Population *pop, const Town *towns, int town_count,
+                         const int *insee_to_idx, int **coverage,
+                         const int *coverage_size, int total_inhabitants);
 
 #endif

--- a/apps/panacee-genetics/src/domain/town/town.c
+++ b/apps/panacee-genetics/src/domain/town/town.c
@@ -16,7 +16,7 @@ double haversine_km(double lat1, double lon1, double lat2, double lon2)
     return EARTH_RADIUS_KM * 2.0 * atan2(sqrt(a), sqrt(1.0 - a));
 }
 
-int inhabitant_count(Town *towns, int size)
+int inhabitant_count(const Town *towns, int size)
 {
     int result = 0;
     int i;
@@ -27,7 +27,8 @@ int inhabitant_count(Town *towns, int size)
 
 /* Precompute coverage lists: for each town, which towns are within radius.
    Uses a latitude bounding box to skip most pairs before calling haversine. */
-void precompute_coverage(Town *towns, int town_count, int ***coverage, int **coverage_size)
+void precompute_coverage(const Town *towns, int town_count,
+                         int ***coverage, int **coverage_size)
 {
     int i, j, cnt;
     double dlat_max = RADIUS_HOSPITAL_KM / 111.0;

--- a/apps/panacee-genetics/src/domain/town/town.c
+++ b/apps/panacee-genetics/src/domain/town/town.c
@@ -48,8 +48,15 @@ void precompute_coverage(Town *towns, int town_count, int ***coverage, int **cov
                              towns[j].latitude, towns[j].longitude) <= RADIUS_HOSPITAL_KM)
                 tmp[cnt++] = j;
         }
-        (*coverage)[i] = malloc(cnt * sizeof(int));
-        memcpy((*coverage)[i], tmp, cnt * sizeof(int));
+        if (cnt > 0)
+        {
+            (*coverage)[i] = malloc(cnt * sizeof(int));
+            memcpy((*coverage)[i], tmp, cnt * sizeof(int));
+        }
+        else
+        {
+            (*coverage)[i] = NULL;
+        }
         (*coverage_size)[i] = cnt;
     }
     free(tmp);

--- a/apps/panacee-genetics/src/domain/town/town.c
+++ b/apps/panacee-genetics/src/domain/town/town.c
@@ -63,3 +63,52 @@ void precompute_coverage(const Town *towns, int town_count,
     free(tmp);
     printf("Coverage map done.\n");
 }
+
+void nearest_hospital_per_town(const Hospital *hospitals, int hospital_count,
+                               const Town *towns, int town_count,
+                               const int *insee_to_idx,
+                               int **coverage, const int *coverage_size,
+                               int *nearest_idx,
+                               double *nearest_dist_km)
+{
+    int i, h, k;
+    double *dist;
+    int dist_owned = 0;
+
+    if (nearest_dist_km)
+    {
+        dist = nearest_dist_km;
+    }
+    else
+    {
+        dist = malloc(town_count * sizeof(double));
+        dist_owned = 1;
+    }
+
+    for (i = 0; i < town_count; i++)
+    {
+        nearest_idx[i] = -1;
+        dist[i] = INFINITY_KM;
+    }
+
+    for (h = 0; h < hospital_count; h++)
+    {
+        int j = insee_to_idx[hospitals[h].insee];
+        if (j < 0)
+            continue;
+        for (k = 0; k < coverage_size[j]; k++)
+        {
+            int t = coverage[j][k];
+            double d = haversine_km(towns[j].latitude, towns[j].longitude,
+                                    towns[t].latitude, towns[t].longitude);
+            if (d < dist[t])
+            {
+                dist[t] = d;
+                nearest_idx[t] = h;
+            }
+        }
+    }
+
+    if (dist_owned)
+        free(dist);
+}

--- a/apps/panacee-genetics/src/domain/town/town.h
+++ b/apps/panacee-genetics/src/domain/town/town.h
@@ -1,6 +1,8 @@
 #ifndef TOWN_H
 #define TOWN_H
 
+#include "../hospital/hospital.h"
+
 typedef struct
 {
     int insee;
@@ -16,5 +18,12 @@ double haversine_km(double lat1, double lon1, double lat2, double lon2);
 int inhabitant_count(const Town *towns, int size);
 void precompute_coverage(const Town *towns, int town_count,
                          int ***coverage, int **coverage_size);
+
+void nearest_hospital_per_town(const Hospital *hospitals, int hospital_count,
+                               const Town *towns, int town_count,
+                               const int *insee_to_idx,
+                               int **coverage, const int *coverage_size,
+                               int *nearest_idx,
+                               double *nearest_dist_km);
 
 #endif

--- a/apps/panacee-genetics/src/domain/town/town.h
+++ b/apps/panacee-genetics/src/domain/town/town.h
@@ -1,8 +1,6 @@
 #ifndef TOWN_H
 #define TOWN_H
 
-#define TOWN_COUNT 34437
-
 typedef struct
 {
     int insee;

--- a/apps/panacee-genetics/src/domain/town/town.h
+++ b/apps/panacee-genetics/src/domain/town/town.h
@@ -15,7 +15,8 @@ typedef struct
 } Town;
 
 double haversine_km(double lat1, double lon1, double lat2, double lon2);
-int inhabitant_count(Town *towns, int size);
-void precompute_coverage(Town *towns, int town_count, int ***coverage, int **coverage_size);
+int inhabitant_count(const Town *towns, int size);
+void precompute_coverage(const Town *towns, int town_count,
+                         int ***coverage, int **coverage_size);
 
 #endif

--- a/apps/panacee-genetics/src/genetic.c
+++ b/apps/panacee-genetics/src/genetic.c
@@ -170,7 +170,7 @@ Individual run_genetic(Town *towns, int town_count)
                     mlv_idx = insee_to_idx[current_best.hospitals[mlv_j].insee];
                     if (mlv_idx >= 0)
                     {
-                        MLV_Color mlv_color = towns[mlv_idx].inhabitants_count > TRESHOLD_UHC
+                        MLV_Color mlv_color = towns[mlv_idx].inhabitants_count > THRESHOLD_UHC
                             ? PANACEE_COLOR_BLUE
                             : PANACEE_COLOR_GREEN;
                         MLV_draw_filled_circle(
@@ -285,7 +285,7 @@ Individual run_genetic(Town *towns, int town_count)
                 for (k = 0; k < coverage_size[i]; k++)
                     if (cover_count[coverage[i][k]] == 0)
                         gain += towns[coverage[i][k]].inhabitants_count;
-                if (gain > PENALITY_HOSPITAL)
+                if (gain > PENALTY_HOSPITAL)
                 {
                     result.hospitals[result.size].insee = towns[i].insee;
                     result.hospitals[result.size].beds_count = 0;
@@ -345,7 +345,7 @@ Individual run_genetic(Town *towns, int town_count)
             mlv_idx = insee_to_idx[result.hospitals[mlv_j].insee];
             if (mlv_idx >= 0)
             {
-                MLV_Color mlv_color = towns[mlv_idx].inhabitants_count > TRESHOLD_UHC
+                MLV_Color mlv_color = towns[mlv_idx].inhabitants_count > THRESHOLD_UHC
                     ? PANACEE_COLOR_BLUE
                     : PANACEE_COLOR_GREEN;
                 MLV_draw_filled_circle(

--- a/apps/panacee-genetics/src/genetic.c
+++ b/apps/panacee-genetics/src/genetic.c
@@ -60,7 +60,7 @@ Individual run_genetic(Town *towns, int town_count)
 
 #ifdef USE_MLV
     color_init();
-    mlv_box = getBoundingBox(towns, town_count);
+    mlv_box = get_bounding_box(towns, town_count);
     mlv_height = (int)(MLV_get_desktop_height() * 0.8);
     mlv_sidebar_width = 300;
     mlv_padding = (int)(mlv_height * 0.05);

--- a/apps/panacee-genetics/src/genetic.c
+++ b/apps/panacee-genetics/src/genetic.c
@@ -59,15 +59,40 @@ Individual run_genetic(Town *towns, int town_count)
     srand((unsigned int)time(NULL));
 
 #ifdef USE_MLV
-    color_init();
-    mlv_box = get_bounding_box(towns, town_count);
-    mlv_height = (int)(MLV_get_desktop_height() * 0.8);
-    mlv_sidebar_width = 300;
-    mlv_padding = (int)(mlv_height * 0.05);
-    mlv_cos_lat = cos((mlv_box.min_lat + mlv_box.max_lat) / 2.0 * M_PI / 180.0);
-    mlv_ratio = (mlv_height - 2 * mlv_padding) / (mlv_box.max_lat - mlv_box.min_lat);
-    mlv_width = (int)(mlv_ratio * (mlv_box.max_lon - mlv_box.min_lon) * mlv_cos_lat) + 2 * mlv_padding;
-    MLV_create_window("Panacée Genetics", "Panacée Genetics", mlv_width + mlv_sidebar_width, mlv_height);
+    {
+        double lat_span, lon_span;
+        int desktop_h;
+
+        color_init();
+        mlv_box = get_bounding_box(towns, town_count);
+        lat_span = mlv_box.max_lat - mlv_box.min_lat;
+        lon_span = mlv_box.max_lon - mlv_box.min_lon;
+
+        desktop_h = MLV_get_desktop_height();
+        if (desktop_h < 600) desktop_h = 600;
+        mlv_height = (int)(desktop_h * 0.8);
+
+        mlv_sidebar_width = 300;
+        mlv_padding = (int)(mlv_height * 0.05);
+        if (mlv_padding < 4) mlv_padding = 4;
+
+        mlv_cos_lat = cos((mlv_box.min_lat + mlv_box.max_lat) / 2.0 * M_PI / 180.0);
+
+        if (lat_span > 0.0 && lon_span > 0.0)
+        {
+            mlv_ratio = (mlv_height - 2 * mlv_padding) / lat_span;
+            mlv_width = (int)(mlv_ratio * lon_span * mlv_cos_lat) + 2 * mlv_padding;
+        }
+        else
+        {
+            /* Degenerate dataset (single town / empty): fall back to a square. */
+            mlv_ratio = 1.0;
+            mlv_width = mlv_height;
+        }
+
+        MLV_create_window("Panacée Genetics", "Panacée Genetics",
+                          mlv_width + mlv_sidebar_width, mlv_height);
+    }
 #endif
 
     /* Build a lookup table insee -> town array index, built once for all evaluations */

--- a/apps/panacee-genetics/src/genetic.c
+++ b/apps/panacee-genetics/src/genetic.c
@@ -87,7 +87,7 @@ static void local_search(Individual *result, const Town *towns, int town_count,
     }
 }
 
-Individual run_genetic(Town *towns, int town_count)
+Individual run_genetic(const Town *towns, int town_count)
 {
     int gen, i;
     int stagnation = 0;

--- a/apps/panacee-genetics/src/genetic.c
+++ b/apps/panacee-genetics/src/genetic.c
@@ -87,6 +87,23 @@ static void local_search(Individual *result, const Town *towns, int town_count,
     }
 }
 
+static void init_seed(void)
+{
+    const char *env_seed = getenv("PANACEE_SEED");
+    unsigned int seed;
+    if (env_seed && *env_seed)
+    {
+        seed = (unsigned int)strtoul(env_seed, NULL, 10);
+        printf("Seed (env): %u\n", seed);
+    }
+    else
+    {
+        seed = (unsigned int)time(NULL);
+        printf("Seed (time): %u\n", seed);
+    }
+    srand(seed);
+}
+
 Individual run_genetic(const Town *towns, int town_count)
 {
     int gen, i;
@@ -104,8 +121,7 @@ Individual run_genetic(const Town *towns, int town_count)
     char *covered_overlay;
     MapView view;
 
-    /* seed RNG with current time for different results each run */
-    srand((unsigned int)time(NULL));
+    init_seed();
 
     map_init(&view, towns, town_count);
 
@@ -134,16 +150,18 @@ Individual run_genetic(const Town *towns, int town_count)
     {
         Individual current_best = best_individual(&pop);
         double best_score = current_best.fitness.fitness_score;
+        int improved = best_score > prev_best;
 
-        printf("Gen %4d | fitness: %.0f | hop: %d | CHRU: %d | desert: %d (%.1f%%)\n",
-               gen,
-               best_score,
-               current_best.fitness.hospital_count,
-               current_best.fitness.uhc_count,
-               current_best.fitness.distant_resident_count,
-               (double)current_best.fitness.distant_resident_percent);
+        if (improved || gen % PROGRESS_INTERVAL == 0)
+            printf("Gen %4d | fitness: %.0f | hop: %d | CHRU: %d | desert: %d (%.1f%%)\n",
+                   gen,
+                   best_score,
+                   current_best.fitness.hospital_count,
+                   current_best.fitness.uhc_count,
+                   current_best.fitness.distant_resident_count,
+                   (double)current_best.fitness.distant_resident_percent);
 
-        if (best_score > prev_best)
+        if (improved)
         {
             prev_best = best_score;
             stagnation = 0;

--- a/apps/panacee-genetics/src/genetic.c
+++ b/apps/panacee-genetics/src/genetic.c
@@ -309,6 +309,12 @@ Individual run_genetic(Town *towns, int town_count)
     }
     printf("Local search done.\n");
 
+    /* Recompute fitness statistics — local search added hospitals but did
+       not update result.fitness, so all printed/exported numbers below
+       would otherwise reflect the pre-local-search state. */
+    evaluate(&result, towns, town_count, insee_to_idx, coverage,
+             coverage_size, total_inhabitants);
+
     /* Compute beds per hospital (post-optimization) */
     compute_beds(&result, towns, town_count, insee_to_idx, coverage, coverage_size);
 

--- a/apps/panacee-genetics/src/genetic.c
+++ b/apps/panacee-genetics/src/genetic.c
@@ -1,41 +1,91 @@
 #include "genetic.h"
 #include "infrastructure/exporter/exporter.h"
-#include <stdlib.h>
+#include "presentation/map/map.h"
+
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
-#ifdef USE_MLV
-#include <MLV/MLV_all.h>
-#include <math.h>
-#include "presentation/color/color.h"
-#include "presentation/map/map.h"
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-static void mlv_loading(Town *towns, int town_count,
-                         int padding, double min_lon, double min_lat,
-                         double ratio, double cos_lat, int height, int sidebar_x,
-                         const char *msg)
+static int *build_insee_to_idx(const Town *towns, int town_count)
 {
-    int j;
-    MLV_clear_window(MLV_COLOR_BLACK);
-    for (j = 0; j < town_count; j++)
+    int *table = malloc(INSEE_MAX * sizeof(int));
+    int i;
+
+    for (i = 0; i < INSEE_MAX; i++)
+        table[i] = -1;
+    for (i = 0; i < town_count; i++)
     {
-        MLV_draw_filled_circle(
-            padding + (int)((towns[j].longitude - min_lon) * ratio * cos_lat),
-            height - padding - (int)((towns[j].latitude - min_lat) * ratio),
-            1,
-            PANACEE_COLOR_ORANGE
-        );
+        if (towns[i].insee < 0 || towns[i].insee >= INSEE_MAX)
+        {
+            fprintf(stderr,
+                    "Warning: INSEE %d out of [0,%d), skipping\n",
+                    towns[i].insee, INSEE_MAX);
+            continue;
+        }
+        table[towns[i].insee] = i;
     }
-    MLV_draw_line(sidebar_x, 0, sidebar_x, height, MLV_COLOR_WHITE);
-    MLV_draw_text(sidebar_x + padding, height / 2, msg, MLV_COLOR_WHITE);
-    MLV_actualise_window();
+    return table;
 }
-#endif
+
+static void compute_covered(char *covered,
+                            const Individual *ind, int town_count,
+                            const int *insee_to_idx,
+                            int **coverage, const int *coverage_size)
+{
+    int i, k;
+    memset(covered, 0, town_count);
+    for (i = 0; i < ind->size; i++)
+    {
+        int j = insee_to_idx[ind->hospitals[i].insee];
+        if (j < 0) continue;
+        for (k = 0; k < coverage_size[j]; k++)
+            covered[coverage[j][k]] = 1;
+    }
+}
+
+static void local_search(Individual *result, const Town *towns, int town_count,
+                         const int *insee_to_idx,
+                         int **coverage, const int *coverage_size)
+{
+    int improved = 1;
+    int i, k;
+
+    while (improved)
+    {
+        int *cover_count = calloc(town_count, sizeof(int));
+
+        improved = 0;
+        for (i = 0; i < result->size; i++)
+        {
+            int j = insee_to_idx[result->hospitals[i].insee];
+            if (j >= 0)
+                for (k = 0; k < coverage_size[j]; k++)
+                    cover_count[coverage[j][k]]++;
+        }
+
+        for (i = 0; i < town_count; i++)
+        {
+            int gain;
+            if (cover_count[i] > 0)
+                continue;
+            gain = 0;
+            for (k = 0; k < coverage_size[i]; k++)
+                if (cover_count[coverage[i][k]] == 0)
+                    gain += towns[coverage[i][k]].inhabitants_count;
+            if (gain > PENALTY_HOSPITAL)
+            {
+                result->hospitals[result->size].insee = towns[i].insee;
+                result->hospitals[result->size].beds_count = 0;
+                result->size++;
+                for (k = 0; k < coverage_size[i]; k++)
+                    cover_count[coverage[i][k]]++;
+                improved = 1;
+            }
+        }
+        free(cover_count);
+    }
+}
 
 Individual run_genetic(Town *towns, int town_count)
 {
@@ -49,74 +99,19 @@ Individual run_genetic(Town *towns, int town_count)
     int **coverage;
     int *coverage_size;
     int total_inhabitants;
-#ifdef USE_MLV
-    BoundingBox mlv_box;
-    int mlv_height, mlv_sidebar_width, mlv_width, mlv_padding;
-    double mlv_ratio, mlv_cos_lat;
-#endif
+    int total_beds;
+    int covered_inhabitants;
+    char *covered_overlay;
+    MapView view;
 
     /* seed RNG with current time for different results each run */
     srand((unsigned int)time(NULL));
 
-#ifdef USE_MLV
-    {
-        double lat_span, lon_span;
-        int desktop_h;
+    map_init(&view, towns, town_count);
 
-        color_init();
-        mlv_box = get_bounding_box(towns, town_count);
-        lat_span = mlv_box.max_lat - mlv_box.min_lat;
-        lon_span = mlv_box.max_lon - mlv_box.min_lon;
+    insee_to_idx = build_insee_to_idx(towns, town_count);
 
-        desktop_h = MLV_get_desktop_height();
-        if (desktop_h < 600) desktop_h = 600;
-        mlv_height = (int)(desktop_h * 0.8);
-
-        mlv_sidebar_width = 300;
-        mlv_padding = (int)(mlv_height * 0.05);
-        if (mlv_padding < 4) mlv_padding = 4;
-
-        mlv_cos_lat = cos((mlv_box.min_lat + mlv_box.max_lat) / 2.0 * M_PI / 180.0);
-
-        if (lat_span > 0.0 && lon_span > 0.0)
-        {
-            mlv_ratio = (mlv_height - 2 * mlv_padding) / lat_span;
-            mlv_width = (int)(mlv_ratio * lon_span * mlv_cos_lat) + 2 * mlv_padding;
-        }
-        else
-        {
-            /* Degenerate dataset (single town / empty): fall back to a square. */
-            mlv_ratio = 1.0;
-            mlv_width = mlv_height;
-        }
-
-        MLV_create_window("Panacée Genetics", "Panacée Genetics",
-                          mlv_width + mlv_sidebar_width, mlv_height);
-    }
-#endif
-
-    /* Build a lookup table insee -> town array index, built once for all evaluations */
-    insee_to_idx = malloc(INSEE_MAX * sizeof(int));
-    for (i = 0; i < INSEE_MAX; i++)
-        insee_to_idx[i] = -1;
-    for (i = 0; i < town_count; i++)
-    {
-        if (towns[i].insee < 0 || towns[i].insee >= INSEE_MAX)
-        {
-            fprintf(stderr,
-                    "Warning: INSEE %d out of [0,%d), skipping\n",
-                    towns[i].insee, INSEE_MAX);
-            continue;
-        }
-        insee_to_idx[towns[i].insee] = i;
-    }
-
-#ifdef USE_MLV
-    mlv_loading(towns, town_count, mlv_padding,
-                mlv_box.min_lon, mlv_box.min_lat, mlv_ratio, mlv_cos_lat,
-                mlv_height, mlv_padding * 2 + (int)((mlv_box.max_lon - mlv_box.min_lon) * mlv_ratio * mlv_cos_lat),
-                "Calcul de la couverture...");
-#endif
+    map_draw_loading(&view, towns, town_count, "Calcul de la couverture...");
     precompute_coverage(towns, town_count, &coverage, &coverage_size);
 
     total_inhabitants = TOTAL_INHABITANTS;
@@ -128,21 +123,12 @@ Individual run_genetic(Town *towns, int town_count)
                     data_total, TOTAL_INHABITANTS);
     }
 
-#ifdef USE_MLV
-    mlv_loading(towns, town_count, mlv_padding,
-                mlv_box.min_lon, mlv_box.min_lat, mlv_ratio, mlv_cos_lat,
-                mlv_height, mlv_padding * 2 + (int)((mlv_box.max_lon - mlv_box.min_lon) * mlv_ratio * mlv_cos_lat),
-                "Initialisation de la population...");
-#endif
+    map_draw_loading(&view, towns, town_count, "Initialisation de la population...");
     pop = init_population(towns, town_count, coverage, coverage_size);
 
-#ifdef USE_MLV
-    mlv_loading(towns, town_count, mlv_padding,
-                mlv_box.min_lon, mlv_box.min_lat, mlv_ratio, mlv_cos_lat,
-                mlv_height, mlv_padding * 2 + (int)((mlv_box.max_lon - mlv_box.min_lon) * mlv_ratio * mlv_cos_lat),
-                "Evaluation de la generation initiale...");
-#endif
-    evaluate_population(&pop, towns, town_count, insee_to_idx, coverage, coverage_size, total_inhabitants);
+    map_draw_loading(&view, towns, town_count, "Evaluation de la generation initiale...");
+    evaluate_population(&pop, towns, town_count, insee_to_idx, coverage,
+                        coverage_size, total_inhabitants);
 
     for (gen = 0; gen < MAX_GENERATIONS; gen++)
     {
@@ -161,7 +147,7 @@ Individual run_genetic(Town *towns, int town_count)
         {
             prev_best = best_score;
             stagnation = 0;
-            current_mutation_rate = MUTATION_RATE; /* reset mutation rate on improvement */
+            current_mutation_rate = MUTATION_RATE;
         }
         else
         {
@@ -182,171 +168,69 @@ Individual run_genetic(Town *towns, int town_count)
             break;
         }
 
-#ifdef USE_MLV
-        {
-            int mlv_j, mlv_idx, mlv_sx, mlv_tx, mlv_ty;
-            mlv_sx = mlv_padding * 2 + (int)((mlv_box.max_lon - mlv_box.min_lon) * mlv_ratio * mlv_cos_lat);
-            mlv_tx = mlv_sx + mlv_padding;
-            if (stagnation == 0)
-            {
-                MLV_clear_window(MLV_COLOR_BLACK);
-                for (mlv_j = 0; mlv_j < town_count; mlv_j++)
-                {
-                    MLV_draw_filled_circle(
-                        mlv_padding + (int)((towns[mlv_j].longitude - mlv_box.min_lon) * mlv_ratio * mlv_cos_lat),
-                        mlv_height - mlv_padding - (int)((towns[mlv_j].latitude - mlv_box.min_lat) * mlv_ratio),
-                        1,
-                        PANACEE_COLOR_ORANGE
-                    );
-                }
-                for (mlv_j = 0; mlv_j < current_best.size; mlv_j++)
-                {
-                    mlv_idx = insee_to_idx[current_best.hospitals[mlv_j].insee];
-                    if (mlv_idx >= 0)
-                    {
-                        MLV_Color mlv_color = towns[mlv_idx].inhabitants_count > THRESHOLD_UHC
-                            ? PANACEE_COLOR_BLUE
-                            : PANACEE_COLOR_GREEN;
-                        MLV_draw_filled_circle(
-                            mlv_padding + (int)((towns[mlv_idx].longitude - mlv_box.min_lon) * mlv_ratio * mlv_cos_lat),
-                            mlv_height - mlv_padding - (int)((towns[mlv_idx].latitude - mlv_box.min_lat) * mlv_ratio),
-                            5,
-                            mlv_color
-                        );
-                    }
-                }
-                MLV_draw_line(mlv_sx, 0, mlv_sx, mlv_height, MLV_COLOR_WHITE);
-            }
-            MLV_draw_filled_rectangle(mlv_sx + 1, 0, mlv_sidebar_width, mlv_height, MLV_COLOR_BLACK);
-            MLV_draw_line(mlv_sx, 0, mlv_sx, mlv_height, MLV_COLOR_WHITE);
-            mlv_ty = mlv_padding;
-            MLV_draw_text(mlv_tx, mlv_ty, "Generation       : %d", MLV_COLOR_WHITE, gen);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "Hopitaux         : %d", MLV_COLOR_WHITE, current_best.fitness.hospital_count);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "CHRU             : %d", MLV_COLOR_WHITE, current_best.fitness.uhc_count);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "Habitants eloignes : %d", MLV_COLOR_WHITE,
-                          current_best.fitness.distant_resident_count);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "%% pop desert     : %.2f", MLV_COLOR_WHITE,
-                          current_best.fitness.distant_resident_percent);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "Villes eloignees : %d", MLV_COLOR_WHITE,
-                          current_best.fitness.distant_town_count);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "%% communes desert: %.2f", MLV_COLOR_WHITE,
-                          current_best.fitness.distant_town_percent);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "FITNESS          : %.0f", MLV_COLOR_WHITE, best_score);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "Taille population: %d", MLV_COLOR_WHITE, POPULATION_SIZE);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "Fitness moyenne  : %.0f", MLV_COLOR_WHITE,
-                          current_best.fitness.fitness_average);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "Stagnation       : %d / %d", MLV_COLOR_WHITE, stagnation, STAGNATION_LIMIT);
-            mlv_ty += 30;
-            MLV_draw_text(mlv_tx, mlv_ty, "Mutation         : %.2f", MLV_COLOR_WHITE, current_mutation_rate);
-            MLV_actualise_window();
-        }
-#endif
+        map_draw_state(&view, towns, town_count,
+                       &current_best, insee_to_idx,
+                       gen, stagnation, STAGNATION_LIMIT,
+                       current_mutation_rate,
+                       current_best.fitness.fitness_average,
+                       stagnation == 0);
 
         /* Build next generation */
         next_pop.size = POPULATION_SIZE;
         next_pop.individuals = malloc(POPULATION_SIZE * sizeof(Individual));
 
         /* Elitism: carry the best individual unchanged into the next generation */
-
-        Individual elite = best_individual(&pop);
-        next_pop.individuals[0].hospitals = malloc(town_count * sizeof(Hospital));
-        next_pop.individuals[0].size = elite.size;
-        memcpy(next_pop.individuals[0].hospitals,
-               elite.hospitals,
-               elite.size * sizeof(Hospital));
-        next_pop.individuals[0].fitness = elite.fitness;
+        {
+            Individual elite = best_individual(&pop);
+            next_pop.individuals[0].hospitals =
+                malloc(town_count * sizeof(Hospital));
+            next_pop.individuals[0].size = elite.size;
+            memcpy(next_pop.individuals[0].hospitals,
+                   elite.hospitals,
+                   elite.size * sizeof(Hospital));
+            next_pop.individuals[0].fitness = elite.fitness;
+        }
 
         for (i = 1; i < POPULATION_SIZE; i++)
         {
             Individual p1 = tournament_select(&pop);
             Individual p2 = tournament_select(&pop);
             next_pop.individuals[i] = crossover(&p1, &p2, town_count);
-            mutate(&next_pop.individuals[i], towns, town_count, current_mutation_rate,
-                   coverage, coverage_size, insee_to_idx);
+            mutate(&next_pop.individuals[i], towns, town_count,
+                   current_mutation_rate, coverage, coverage_size, insee_to_idx);
             remove_redundant(&next_pop.individuals[i], coverage, coverage_size,
                              insee_to_idx, town_count);
         }
 
         free_population(&pop);
         pop = next_pop;
-        evaluate_population(&pop, towns, town_count, insee_to_idx, coverage, coverage_size, total_inhabitants);
+        evaluate_population(&pop, towns, town_count, insee_to_idx,
+                            coverage, coverage_size, total_inhabitants);
     }
 
     /* Copy the best solution before freeing the population */
-
-    Individual b = best_individual(&pop);
-    result.hospitals = malloc(town_count * sizeof(Hospital)); /* town_count: upper bound for local search */
-    result.size = b.size;
-    result.fitness = b.fitness;
-    memcpy(result.hospitals, b.hospitals, b.size * sizeof(Hospital));
-
+    {
+        Individual b = best_individual(&pop);
+        result.hospitals = malloc(town_count * sizeof(Hospital));
+        result.size = b.size;
+        result.fitness = b.fitness;
+        memcpy(result.hospitals, b.hospitals, b.size * sizeof(Hospital));
+    }
     free_population(&pop);
 
-    /* Local search: greedily add hospitals as long as the coverage gain > penalty */
     printf("Running local search...\n");
-    {
-        int improved = 1;
-        int i, k;
-        while (improved)
-        {
-            improved = 0;
-            int *cover_count = calloc(town_count, sizeof(int));
-
-            for (i = 0; i < result.size; i++)
-            {
-                int j = insee_to_idx[result.hospitals[i].insee];
-                if (j >= 0)
-                    for (k = 0; k < coverage_size[j]; k++)
-                        cover_count[coverage[j][k]]++;
-            }
-
-            for (i = 0; i < town_count; i++)
-            {
-                if (cover_count[i] > 0)
-                    continue;
-                /* Count inhabitants newly covered by a hospital at town i */
-                int gain = 0;
-                for (k = 0; k < coverage_size[i]; k++)
-                    if (cover_count[coverage[i][k]] == 0)
-                        gain += towns[coverage[i][k]].inhabitants_count;
-                if (gain > PENALTY_HOSPITAL)
-                {
-                    result.hospitals[result.size].insee = towns[i].insee;
-                    result.hospitals[result.size].beds_count = 0;
-                    result.size++;
-                    for (k = 0; k < coverage_size[i]; k++)
-                        cover_count[coverage[i][k]]++;
-                    improved = 1;
-                }
-            }
-            free(cover_count);
-        }
-    }
+    local_search(&result, towns, town_count, insee_to_idx, coverage, coverage_size);
     printf("Local search done.\n");
 
-    /* Recompute fitness statistics — local search added hospitals but did
-       not update result.fitness, so all printed/exported numbers below
-       would otherwise reflect the pre-local-search state. */
     evaluate(&result, towns, town_count, insee_to_idx, coverage,
              coverage_size, total_inhabitants);
 
-    /* Compute beds per hospital (post-optimization) */
     compute_beds(&result, towns, town_count, insee_to_idx, coverage, coverage_size);
 
     printf("\n=== Final result: %d hospitals ===\n", result.size);
 
-    int total_beds = 0;
-    int covered_inhabitants = total_inhabitants - result.fitness.distant_resident_count;
+    total_beds = 0;
+    covered_inhabitants = total_inhabitants - result.fitness.distant_resident_count;
     for (i = 0; i < result.size; i++)
         total_beds += result.hospitals[i].beds_count;
     printf("Total beds: %d\n", total_beds);
@@ -355,76 +239,28 @@ Individual run_genetic(Town *towns, int town_count)
 
     if (covered_inhabitants > 0)
         printf("Beds per 1000 covered inhabitants: %.2f (target: %.2f)\n",
-               (double)total_beds / (covered_inhabitants / 1000.0), BEDS_PER_INHABITANT);
+               (double)total_beds / (covered_inhabitants / 1000.0),
+               BEDS_PER_INHABITANT);
 
     export_result_csv(&result, towns, insee_to_idx, "./src/results/hospitals.csv");
     export_fitness_csv(&result.fitness, "./src/results/fitness.csv");
     export_towns_status_csv(&result, towns, town_count, insee_to_idx, coverage,
                             coverage_size, "./src/results/towns_status.csv");
 
+    covered_overlay = calloc(town_count, 1);
+    compute_covered(covered_overlay, &result, town_count,
+                    insee_to_idx, coverage, coverage_size);
+    map_draw_final(&view, towns, town_count, &result, insee_to_idx,
+                   covered_overlay, total_beds);
+    free(covered_overlay);
+
+    map_close(&view);
+
     for (i = 0; i < town_count; i++)
         free(coverage[i]);
     free(coverage);
     free(coverage_size);
     free(insee_to_idx);
-
-#ifdef USE_MLV
-    {
-        int mlv_j, mlv_idx, mlv_sx, mlv_tx, mlv_ty;
-        mlv_sx = mlv_padding * 2 + (int)((mlv_box.max_lon - mlv_box.min_lon) * mlv_ratio * mlv_cos_lat);
-        mlv_tx = mlv_sx + mlv_padding;
-        MLV_clear_window(MLV_COLOR_BLACK);
-        for (mlv_j = 0; mlv_j < town_count; mlv_j++)
-            MLV_draw_filled_circle(
-                mlv_padding + (int)((towns[mlv_j].longitude - mlv_box.min_lon) * mlv_ratio * mlv_cos_lat),
-                mlv_height - mlv_padding - (int)((towns[mlv_j].latitude - mlv_box.min_lat) * mlv_ratio),
-                1,
-                PANACEE_COLOR_ORANGE);
-        for (mlv_j = 0; mlv_j < result.size; mlv_j++)
-        {
-            mlv_idx = insee_to_idx[result.hospitals[mlv_j].insee];
-            if (mlv_idx >= 0)
-            {
-                MLV_Color mlv_color = towns[mlv_idx].inhabitants_count > THRESHOLD_UHC
-                    ? PANACEE_COLOR_BLUE
-                    : PANACEE_COLOR_GREEN;
-                MLV_draw_filled_circle(
-                    mlv_padding + (int)((towns[mlv_idx].longitude - mlv_box.min_lon) * mlv_ratio * mlv_cos_lat),
-                    mlv_height - mlv_padding - (int)((towns[mlv_idx].latitude - mlv_box.min_lat) * mlv_ratio),
-                    5,
-                    mlv_color);
-            }
-        }
-        MLV_draw_line(mlv_sx, 0, mlv_sx, mlv_height, MLV_COLOR_WHITE);
-        mlv_ty = mlv_padding;
-        MLV_draw_text(mlv_tx, mlv_ty, "Resultat final", MLV_COLOR_WHITE);
-        mlv_ty += 30;
-        MLV_draw_text(mlv_tx, mlv_ty, "Hopitaux         : %d", MLV_COLOR_WHITE, result.fitness.hospital_count);
-        mlv_ty += 30;
-        MLV_draw_text(mlv_tx, mlv_ty, "CHRU             : %d", MLV_COLOR_WHITE, result.fitness.uhc_count);
-        mlv_ty += 30;
-        MLV_draw_text(mlv_tx, mlv_ty, "Habitants eloignes : %d", MLV_COLOR_WHITE,
-                      result.fitness.distant_resident_count);
-        mlv_ty += 30;
-        MLV_draw_text(mlv_tx, mlv_ty, "%% pop desert     : %.2f", MLV_COLOR_WHITE,
-                      result.fitness.distant_resident_percent);
-        mlv_ty += 30;
-        MLV_draw_text(mlv_tx, mlv_ty, "Villes eloignees : %d", MLV_COLOR_WHITE,
-                      result.fitness.distant_town_count);
-        mlv_ty += 30;
-        MLV_draw_text(mlv_tx, mlv_ty, "%% communes desert: %.2f", MLV_COLOR_WHITE,
-                      result.fitness.distant_town_percent);
-        mlv_ty += 30;
-        MLV_draw_text(mlv_tx, mlv_ty, "FITNESS          : %.0f", MLV_COLOR_WHITE, result.fitness.fitness_score);
-        mlv_ty += 30;
-        MLV_draw_text(mlv_tx, mlv_ty, "Lits totaux      : %d", MLV_COLOR_WHITE, total_beds);
-        mlv_ty += 60;
-        MLV_draw_text(mlv_tx, mlv_ty, "Touche pour quitter...", MLV_COLOR_WHITE);
-        MLV_actualise_window();
-        MLV_wait_keyboard(NULL, NULL, NULL);
-        MLV_free_window();
-    }
-#endif
 
     return result;
 }

--- a/apps/panacee-genetics/src/genetic.c
+++ b/apps/panacee-genetics/src/genetic.c
@@ -71,11 +71,20 @@ Individual run_genetic(Town *towns, int town_count)
 #endif
 
     /* Build a lookup table insee -> town array index, built once for all evaluations */
-    insee_to_idx = malloc(100000 * sizeof(int));
-    for (i = 0; i < 100000; i++)
+    insee_to_idx = malloc(INSEE_MAX * sizeof(int));
+    for (i = 0; i < INSEE_MAX; i++)
         insee_to_idx[i] = -1;
     for (i = 0; i < town_count; i++)
+    {
+        if (towns[i].insee < 0 || towns[i].insee >= INSEE_MAX)
+        {
+            fprintf(stderr,
+                    "Warning: INSEE %d out of [0,%d), skipping\n",
+                    towns[i].insee, INSEE_MAX);
+            continue;
+        }
         insee_to_idx[towns[i].insee] = i;
+    }
 
 #ifdef USE_MLV
     mlv_loading(towns, town_count, mlv_padding,

--- a/apps/panacee-genetics/src/genetic.h
+++ b/apps/panacee-genetics/src/genetic.h
@@ -19,6 +19,7 @@
 #define STAGNATION_LIMIT 200
 
 #define INSEE_MAX 100000
+#define INFINITY_KM 1e18
 
 Individual run_genetic(const Town *towns, int town_count);
 

--- a/apps/panacee-genetics/src/genetic.h
+++ b/apps/panacee-genetics/src/genetic.h
@@ -18,6 +18,8 @@
 #define MAX_GENERATIONS 200000
 #define STAGNATION_LIMIT 200
 
+#define INSEE_MAX 100000
+
 Individual run_genetic(Town *towns, int town_count);
 
 #endif

--- a/apps/panacee-genetics/src/genetic.h
+++ b/apps/panacee-genetics/src/genetic.h
@@ -6,9 +6,9 @@
 
 #define EARTH_RADIUS_KM 6371.0
 #define RADIUS_HOSPITAL_KM 10.0     /* coverage radius of a hospital (km)         */
-#define PENALITY_HOSPITAL 5000      /* fitness penalty per hospital               */
+#define PENALTY_HOSPITAL 5000      /* fitness penalty per hospital               */
 #define BONUS_UHC 4000              /* fitness bonus per CHRU                     */
-#define TRESHOLD_UHC 80000          /* population threshold for CHRU status       */
+#define THRESHOLD_UHC 80000          /* population threshold for CHRU status       */
 #define TOTAL_INHABITANTS 65141355  /* INSEE 2025: France metropolitaine sans Corse */
 #define BEDS_PER_INHABITANT 5.40 /* target: beds per 1000 covered inhabitants   */
 #define INIT_HOSPITAL_RATIO 0.05 /* ~5% of towns have a hospital at init        */

--- a/apps/panacee-genetics/src/genetic.h
+++ b/apps/panacee-genetics/src/genetic.h
@@ -20,6 +20,6 @@
 
 #define INSEE_MAX 100000
 
-Individual run_genetic(Town *towns, int town_count);
+Individual run_genetic(const Town *towns, int town_count);
 
 #endif

--- a/apps/panacee-genetics/src/genetic.h
+++ b/apps/panacee-genetics/src/genetic.h
@@ -17,6 +17,7 @@
 #define MUTATION_RATE 0.95       /* mutation probability per individual         */
 #define MAX_GENERATIONS 200000
 #define STAGNATION_LIMIT 200
+#define PROGRESS_INTERVAL 25
 
 #define INSEE_MAX 100000
 #define INFINITY_KM 1e18

--- a/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
+++ b/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
@@ -48,7 +48,7 @@ void export_result_csv(const Individual *result, Town *towns,
                     towns[j].department_code,
                     towns[j].department_name,
                     towns[j].inhabitants_count,
-                    towns[j].inhabitants_count > TRESHOLD_UHC ? 1 : 0,
+                    towns[j].inhabitants_count > THRESHOLD_UHC ? 1 : 0,
                     result->hospitals[i].beds_count);
     }
     fclose(f);

--- a/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
+++ b/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
@@ -1,16 +1,63 @@
 #include "exporter.h"
 #include "../../genetic.h"
+
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+static void ensure_parent_dir(const char *path)
+{
+    char buffer[1024];
+    size_t len;
+    char *p;
+
+    len = strlen(path);
+    if (len == 0 || len >= sizeof buffer)
+        return;
+    memcpy(buffer, path, len + 1);
+
+    for (p = buffer + len; p > buffer; p--)
+        if (*p == '/')
+        {
+            *p = '\0';
+            break;
+        }
+    if (p == buffer)
+        return; /* no directory component */
+
+    for (p = buffer + 1; *p; p++)
+        if (*p == '/')
+        {
+            *p = '\0';
+            if (mkdir(buffer, 0755) != 0 && errno != EEXIST)
+                fprintf(stderr,
+                        "Warning: mkdir(%s) failed: %s\n",
+                        buffer, strerror(errno));
+            *p = '/';
+        }
+    if (mkdir(buffer, 0755) != 0 && errno != EEXIST)
+        fprintf(stderr,
+                "Warning: mkdir(%s) failed: %s\n",
+                buffer, strerror(errno));
+}
+
+static FILE *open_for_write(const char *path)
+{
+    FILE *f;
+    ensure_parent_dir(path);
+    f = fopen(path, "w");
+    if (!f)
+        fprintf(stderr, "Warning: could not open %s for writing: %s\n",
+                path, strerror(errno));
+    return f;
+}
 
 void export_fitness_csv(const Fitness *fitness, const char *path)
 {
-    FILE *f = fopen(path, "w");
-    if (!f)
-    {
-        fprintf(stderr, "Warning: could not open %s for writing\n", path);
-        return;
-    }
+    FILE *f = open_for_write(path);
+    if (!f) return;
     fprintf(f, "hospital_count,uhc_count,distant_resident_count,distant_resident_percent,"
                "distant_town_count,distant_town_percent,fitness_score,fitness_count,fitness_average\n");
     fprintf(f, "%d,%d,%d,%.2f,%d,%.2f,%.2f,%d,%.2f\n",
@@ -31,12 +78,8 @@ void export_result_csv(const Individual *result, const Town *towns,
                        const int *insee_to_idx, const char *path)
 {
     int i;
-    FILE *f = fopen(path, "w");
-    if (!f)
-    {
-        fprintf(stderr, "Warning: could not open %s for writing\n", path);
-        return;
-    }
+    FILE *f = open_for_write(path);
+    if (!f) return;
     fprintf(f, "insee,name,department_code,department_name,inhabitants,is_chru,beds_count\n");
     for (i = 0; i < result->size; i++)
     {
@@ -91,10 +134,9 @@ void export_towns_status_csv(const Individual *result, const Town *towns,
         }
     }
 
-    f = fopen(path, "w");
+    f = open_for_write(path);
     if (!f)
     {
-        fprintf(stderr, "Warning: could not open %s for writing\n", path);
         free(nearest_insee);
         free(nearest_dist);
         return;

--- a/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
+++ b/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
@@ -27,7 +27,7 @@ void export_fitness_csv(const Fitness *fitness, const char *path)
     printf("Fitness exported to %s\n", path);
 }
 
-void export_result_csv(const Individual *result, Town *towns,
+void export_result_csv(const Individual *result, const Town *towns,
                        const int *insee_to_idx, const char *path)
 {
     int i;
@@ -57,9 +57,10 @@ void export_result_csv(const Individual *result, Town *towns,
 
 /* For each town, write its coverage status: assigned hospital INSEE (-1 if desert).
    Assignment uses nearest hospital among those whose 10 km disc covers the town. */
-void export_towns_status_csv(const Individual *result, Town *towns, int town_count,
-                             const int *insee_to_idx, int **coverage,
-                             const int *coverage_size, const char *path)
+void export_towns_status_csv(const Individual *result, const Town *towns,
+                             int town_count, const int *insee_to_idx,
+                             int **coverage, const int *coverage_size,
+                             const char *path)
 {
     int i, k, h;
     FILE *f;

--- a/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
+++ b/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
@@ -105,54 +105,37 @@ void export_towns_status_csv(const Individual *result, const Town *towns,
                              int **coverage, const int *coverage_size,
                              const char *path)
 {
-    int i, k, h;
+    int i;
     FILE *f;
-    int *nearest_insee = malloc(town_count * sizeof(int));
-    double *nearest_dist = malloc(town_count * sizeof(double));
+    int *nearest_idx = malloc(town_count * sizeof(int));
 
-    for (i = 0; i < town_count; i++)
-    {
-        nearest_insee[i] = -1;
-        nearest_dist[i] = INFINITY_KM;
-    }
-
-    for (h = 0; h < result->size; h++)
-    {
-        int j = insee_to_idx[result->hospitals[h].insee];
-        if (j < 0)
-            continue;
-        for (k = 0; k < coverage_size[j]; k++)
-        {
-            int t = coverage[j][k];
-            double d = haversine_km(towns[j].latitude, towns[j].longitude,
-                                    towns[t].latitude, towns[t].longitude);
-            if (d < nearest_dist[t])
-            {
-                nearest_dist[t] = d;
-                nearest_insee[t] = towns[j].insee;
-            }
-        }
-    }
+    nearest_hospital_per_town(result->hospitals, result->size,
+                              towns, town_count,
+                              insee_to_idx, coverage, coverage_size,
+                              nearest_idx, NULL);
 
     f = open_for_write(path);
     if (!f)
     {
-        free(nearest_insee);
-        free(nearest_dist);
+        free(nearest_idx);
         return;
     }
     fprintf(f, "insee,name,department_code,department_name,inhabitants,assigned_hospital_insee\n");
     for (i = 0; i < town_count; i++)
+    {
+        int hidx = nearest_idx[i];
+        int assigned_insee =
+            hidx >= 0 ? result->hospitals[hidx].insee : -1;
         fprintf(f, "%d,\"%s\",%s,\"%s\",%d,%d\n",
                 towns[i].insee,
                 towns[i].name,
                 towns[i].department_code,
                 towns[i].department_name,
                 towns[i].inhabitants_count,
-                nearest_insee[i]);
+                assigned_insee);
+    }
     fclose(f);
     printf("Towns status exported to %s (%d towns)\n", path, town_count);
 
-    free(nearest_insee);
-    free(nearest_dist);
+    free(nearest_idx);
 }

--- a/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
+++ b/apps/panacee-genetics/src/infrastructure/exporter/exporter.c
@@ -113,7 +113,7 @@ void export_towns_status_csv(const Individual *result, const Town *towns,
     for (i = 0; i < town_count; i++)
     {
         nearest_insee[i] = -1;
-        nearest_dist[i] = 1e18;
+        nearest_dist[i] = INFINITY_KM;
     }
 
     for (h = 0; h < result->size; h++)

--- a/apps/panacee-genetics/src/infrastructure/exporter/exporter.h
+++ b/apps/panacee-genetics/src/infrastructure/exporter/exporter.h
@@ -6,9 +6,11 @@
 #include "../../domain/town/town.h"
 
 void export_fitness_csv(const Fitness *fitness, const char *path);
-void export_result_csv(const Individual *result, Town *towns, const int *insee_to_idx, const char *path);
-void export_towns_status_csv(const Individual *result, Town *towns, int town_count,
-                             const int *insee_to_idx, int **coverage,
-                             const int *coverage_size, const char *path);
+void export_result_csv(const Individual *result, const Town *towns,
+                       const int *insee_to_idx, const char *path);
+void export_towns_status_csv(const Individual *result, const Town *towns,
+                             int town_count, const int *insee_to_idx,
+                             int **coverage, const int *coverage_size,
+                             const char *path);
 
 #endif

--- a/apps/panacee-genetics/src/infrastructure/parser/parser.c
+++ b/apps/panacee-genetics/src/infrastructure/parser/parser.c
@@ -1,15 +1,19 @@
+#include "parser.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../../domain/town/town.h"
 
-#define INSEE_COL 0
-#define NAME_COL 1
+#define INSEE_COL           0
+#define NAME_COL            1
 #define DEPARTMENT_CODE_COL 4
 #define DEPARTMENT_NAME_COL 5
-#define INHABITANTS_COL 7
-#define LATITUDE_COL 8
-#define LONGITUDE_COL 9
+#define INHABITANTS_COL     7
+#define LATITUDE_COL        8
+#define LONGITUDE_COL       9
+
+#define LINE_BUFFER 1024
+#define DEFAULT_CSV_PATH "../../data/communes-france-metrople-2025.csv"
 
 static void copy_field(char *dst, const char *src, size_t cap)
 {
@@ -21,57 +25,110 @@ static void copy_field(char *dst, const char *src, size_t cap)
     dst[n] = '\0';
 }
 
-int count_lines(FILE *fptr)
+static int count_lines(FILE *fptr)
 {
     int lines = 0;
-    char buffer[1024];
-    while (fgets(buffer, 1024, fptr))
-        lines++;
+    int started = 0;
+    char buffer[LINE_BUFFER];
+    while (fgets(buffer, LINE_BUFFER, fptr))
+    {
+        size_t len = strlen(buffer);
+        if (!started)
+        {
+            lines++;
+            started = 1;
+        }
+        if (len > 0 && buffer[len - 1] == '\n')
+            started = 0;
+        else if (feof(fptr))
+            started = 0;
+        else
+            fprintf(stderr,
+                    "Warning: CSV row exceeds %d bytes (will be truncated)\n",
+                    LINE_BUFFER - 1);
+    }
     rewind(fptr);
     return lines;
 }
 
-Town *parse(int *count)
+static const char *resolve_path(const char *path)
 {
-    FILE *fptr = fopen("../../data/communes-france-metrople-2025.csv", "r");
+    const char *env;
+    if (path && *path)
+        return path;
+    env = getenv("PANACEE_CSV_PATH");
+    if (env && *env)
+        return env;
+    return DEFAULT_CSV_PATH;
+}
+
+Town *parse(const char *path, int *count)
+{
+    const char *resolved = resolve_path(path);
+    FILE *fptr;
+    int total;
+    Town *towns;
+    char buffer[LINE_BUFFER];
+    int i = 0;
+
+    *count = 0;
+
+    fptr = fopen(resolved, "r");
     if (!fptr)
     {
-        perror("fopen");
+        fprintf(stderr, "fopen(\"%s\"): ", resolved);
+        perror("");
         return NULL;
     }
 
-    int total = count_lines(fptr);
-    Town *towns = malloc(total * sizeof(Town));
-    if (!towns)
+    total = count_lines(fptr);
+    if (total <= 0)
     {
         fclose(fptr);
         return NULL;
     }
 
-    char buffer[1024];
-    int i = 0;
-    while (fgets(buffer, 1024, fptr))
+    towns = malloc(total * sizeof(Town));
+
+    while (fgets(buffer, LINE_BUFFER, fptr))
     {
         int column = 0;
-        char *value = strtok(buffer, ",");
-        Town town = {0};
+        char *value;
+        Town town;
+
+        memset(&town, 0, sizeof town);
+        value = strtok(buffer, ",\n");
         while (value)
         {
-            if (column == INSEE_COL)
+            switch (column)
+            {
+            case INSEE_COL:
                 town.insee = atoi(value);
-            if (column == NAME_COL)
-                copy_field(town.name, value, sizeof(town.name));
-            if (column == DEPARTMENT_CODE_COL)
-                copy_field(town.department_code, value, sizeof(town.department_code));
-            if (column == DEPARTMENT_NAME_COL)
-                copy_field(town.department_name, value, sizeof(town.department_name));
-            if (column == INHABITANTS_COL)
+                break;
+            case NAME_COL:
+                copy_field(town.name, value, sizeof town.name);
+                break;
+            case DEPARTMENT_CODE_COL:
+                copy_field(town.department_code, value,
+                           sizeof town.department_code);
+                break;
+            case DEPARTMENT_NAME_COL:
+                copy_field(town.department_name, value,
+                           sizeof town.department_name);
+                break;
+            case INHABITANTS_COL:
                 town.inhabitants_count = atoi(value);
-            if (column == LATITUDE_COL)
+                break;
+            case LATITUDE_COL:
                 town.latitude = atof(value);
-            if (column == LONGITUDE_COL)
+                break;
+            case LONGITUDE_COL:
                 town.longitude = atof(value);
-            value = strtok(NULL, ",");
+                break;
+            default:
+                break;
+            }
+            value = strtok(NULL, ",\n");
             column++;
         }
         towns[i++] = town;

--- a/apps/panacee-genetics/src/infrastructure/parser/parser.h
+++ b/apps/panacee-genetics/src/infrastructure/parser/parser.h
@@ -3,6 +3,6 @@
 
 #include "../../domain/town/town.h"
 
-Town *parse(int *count);
+Town *parse(const char *path, int *count);
 
 #endif

--- a/apps/panacee-genetics/src/main.c
+++ b/apps/panacee-genetics/src/main.c
@@ -4,13 +4,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    const char *csv_path = (argc > 1) ? argv[1] : NULL;
     int count = 0;
     Town *towns;
     Individual result;
 
-    towns = parse(&count);
+    towns = parse(csv_path, &count);
     if (!towns || count <= 0)
     {
         fprintf(stderr, "fatal: failed to load towns dataset\n");

--- a/apps/panacee-genetics/src/main.c
+++ b/apps/panacee-genetics/src/main.c
@@ -1,11 +1,26 @@
 #include "genetic.h"
 #include "infrastructure/parser/parser.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+
 int main(void)
 {
-    int i = 0;
-    Town *towns = parse(&i);
-    run_genetic(towns, i);
+    int count = 0;
+    Town *towns;
+    Individual result;
 
-    return 0;
+    towns = parse(&count);
+    if (!towns || count <= 0)
+    {
+        fprintf(stderr, "fatal: failed to load towns dataset\n");
+        free(towns);
+        return EXIT_FAILURE;
+    }
+
+    result = run_genetic(towns, count);
+
+    free(result.hospitals);
+    free(towns);
+    return EXIT_SUCCESS;
 }

--- a/apps/panacee-genetics/src/presentation/color/color.c
+++ b/apps/panacee-genetics/src/presentation/color/color.c
@@ -4,13 +4,13 @@
 MLV_Color PANACEE_COLOR_ORANGE;
 MLV_Color PANACEE_COLOR_GREEN;
 MLV_Color PANACEE_COLOR_BLUE;
+MLV_Color PANACEE_COLOR_RED;
 
-void color_init(void) {
-	/*#F29400*/
-	PANACEE_COLOR_ORANGE = MLV_rgba(242, 148, 0, 255);
-	/*#80BA27*/
-	PANACEE_COLOR_GREEN = MLV_rgba(128, 186, 39, 255);
-	/*#0096C7*/
-	PANACEE_COLOR_BLUE = MLV_rgba(0, 150, 199, 255);
+void color_init(void)
+{
+    PANACEE_COLOR_ORANGE = MLV_rgba(242, 148,   0, 255); /* #F29400 */
+    PANACEE_COLOR_GREEN  = MLV_rgba(128, 186,  39, 255); /* #80BA27 */
+    PANACEE_COLOR_BLUE   = MLV_rgba(  0, 150, 199, 255); /* #0096C7 */
+    PANACEE_COLOR_RED    = MLV_rgba(214,  40,  40, 255); /* #D62828 */
 }
 #endif

--- a/apps/panacee-genetics/src/presentation/color/color.h
+++ b/apps/panacee-genetics/src/presentation/color/color.h
@@ -1,18 +1,13 @@
 #ifndef COLOR_H
 #define COLOR_H
 
-typedef struct {
-	int red;
-	int green;
-	int blue;
-} Color;
-
 #ifdef USE_MLV
 #include <MLV/MLV_all.h>
 
 extern MLV_Color PANACEE_COLOR_ORANGE;
 extern MLV_Color PANACEE_COLOR_GREEN;
 extern MLV_Color PANACEE_COLOR_BLUE;
+extern MLV_Color PANACEE_COLOR_RED;
 
 void color_init(void);
 #endif

--- a/apps/panacee-genetics/src/presentation/map/map.c
+++ b/apps/panacee-genetics/src/presentation/map/map.c
@@ -1,6 +1,6 @@
 #include "map.h"
 
-BoundingBox getBoundingBox(Town *towns, int count)
+BoundingBox get_bounding_box(const Town *towns, int count)
 {
     BoundingBox box;
     int i;

--- a/apps/panacee-genetics/src/presentation/map/map.c
+++ b/apps/panacee-genetics/src/presentation/map/map.c
@@ -1,21 +1,35 @@
 #include "map.h"
+#include "../../genetic.h"
+#include "../color/color.h"
+
+#include <math.h>
+
+#ifdef USE_MLV
+#include <MLV/MLV_all.h>
+#endif
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 BoundingBox get_bounding_box(const Town *towns, int count)
 {
     BoundingBox box;
     int i;
 
-    if (count <= 0) {
-        BoundingBox empty = {0, 0, 0, 0};
+    if (count <= 0)
+    {
+        BoundingBox empty;
+        empty.min_lat = empty.max_lat = 0.0;
+        empty.min_lon = empty.max_lon = 0.0;
         return empty;
     }
 
-    box.min_lat = towns[0].latitude;
-    box.max_lat = towns[0].latitude;
-    box.min_lon = towns[0].longitude;
-    box.max_lon = towns[0].longitude;
+    box.min_lat = box.max_lat = towns[0].latitude;
+    box.min_lon = box.max_lon = towns[0].longitude;
 
-    for (i = 1; i < count; i++) {
+    for (i = 1; i < count; i++)
+    {
         if (towns[i].latitude < box.min_lat) box.min_lat = towns[i].latitude;
         else if (towns[i].latitude > box.max_lat) box.max_lat = towns[i].latitude;
 
@@ -24,4 +38,260 @@ BoundingBox get_bounding_box(const Town *towns, int count)
     }
 
     return box;
+}
+
+#ifdef USE_MLV
+
+static int project_x(const MapView *v, double longitude)
+{
+    return v->padding +
+           (int)((longitude - v->box.min_lon) * v->ratio * v->cos_lat);
+}
+
+static int project_y(const MapView *v, double latitude)
+{
+    return v->height - v->padding -
+           (int)((latitude - v->box.min_lat) * v->ratio);
+}
+
+static void draw_country(const MapView *v, const Town *towns, int town_count)
+{
+    int j;
+    for (j = 0; j < town_count; j++)
+        MLV_draw_filled_circle(project_x(v, towns[j].longitude),
+                               project_y(v, towns[j].latitude),
+                               1, PANACEE_COLOR_ORANGE);
+}
+
+static void draw_hospitals(const MapView *v, const Individual *ind,
+                           const Town *towns, const int *insee_to_idx)
+{
+    int j, idx;
+    for (j = 0; j < ind->size; j++)
+    {
+        MLV_Color color;
+        idx = insee_to_idx[ind->hospitals[j].insee];
+        if (idx < 0)
+            continue;
+        color = towns[idx].inhabitants_count > THRESHOLD_UHC
+                    ? PANACEE_COLOR_BLUE
+                    : PANACEE_COLOR_GREEN;
+        MLV_draw_filled_circle(project_x(v, towns[idx].longitude),
+                               project_y(v, towns[idx].latitude),
+                               5, color);
+    }
+}
+
+static void draw_deserts(const MapView *v, const Town *towns, int town_count,
+                         const char *covered)
+{
+    int j;
+    for (j = 0; j < town_count; j++)
+        if (!covered[j])
+            MLV_draw_filled_circle(project_x(v, towns[j].longitude),
+                                   project_y(v, towns[j].latitude),
+                                   2, PANACEE_COLOR_RED);
+}
+
+static void clear_sidebar(const MapView *v)
+{
+    MLV_draw_filled_rectangle(v->sidebar_x + 1, 0,
+                              v->sidebar_w, v->height,
+                              MLV_COLOR_BLACK);
+    MLV_draw_line(v->sidebar_x, 0, v->sidebar_x, v->height, MLV_COLOR_WHITE);
+}
+
+static int sidebar_text_x(const MapView *v) { return v->sidebar_x + v->padding; }
+
+#endif /* USE_MLV */
+
+int map_init(MapView *view, const Town *towns, int town_count)
+{
+#ifdef USE_MLV
+    int desktop_h;
+    double lat_span, lon_span;
+
+    color_init();
+    view->box = get_bounding_box(towns, town_count);
+    lat_span = view->box.max_lat - view->box.min_lat;
+    lon_span = view->box.max_lon - view->box.min_lon;
+
+    desktop_h = MLV_get_desktop_height();
+    if (desktop_h < 600) desktop_h = 600;
+    view->height = (int)(desktop_h * 0.8);
+
+    view->padding = (int)(view->height * 0.05);
+    if (view->padding < 4) view->padding = 4;
+    view->sidebar_w = MAP_SIDEBAR_WIDTH;
+
+    view->cos_lat = cos((view->box.min_lat + view->box.max_lat) / 2.0
+                        * M_PI / 180.0);
+
+    if (lat_span > 0.0 && lon_span > 0.0)
+    {
+        view->ratio = (view->height - 2 * view->padding) / lat_span;
+        view->map_width =
+            (int)(view->ratio * lon_span * view->cos_lat) + 2 * view->padding;
+    }
+    else
+    {
+        view->ratio = 1.0;
+        view->map_width = view->height;
+    }
+    view->sidebar_x = view->map_width;
+    view->initialised = 1;
+
+    MLV_create_window("Panacée Genetics", "Panacée Genetics",
+                      view->map_width + view->sidebar_w, view->height);
+    return 1;
+#else
+    (void)towns;
+    (void)town_count;
+    view->initialised = 0;
+    return 0;
+#endif
+}
+
+void map_close(MapView *view)
+{
+#ifdef USE_MLV
+    if (view->initialised)
+    {
+        MLV_free_window();
+        view->initialised = 0;
+    }
+#else
+    (void)view;
+#endif
+}
+
+void map_draw_loading(const MapView *v, const Town *towns, int town_count,
+                      const char *message)
+{
+#ifdef USE_MLV
+    if (!v->initialised) return;
+    MLV_clear_window(MLV_COLOR_BLACK);
+    draw_country(v, towns, town_count);
+    MLV_draw_line(v->sidebar_x, 0, v->sidebar_x, v->height, MLV_COLOR_WHITE);
+    MLV_draw_text(sidebar_text_x(v), v->height / 2, message, MLV_COLOR_WHITE);
+    MLV_actualise_window();
+#else
+    (void)v; (void)towns; (void)town_count; (void)message;
+#endif
+}
+
+void map_draw_state(const MapView *v, const Town *towns, int town_count,
+                    const Individual *best, const int *insee_to_idx,
+                    int generation, int stagnation, int stagnation_limit,
+                    double mutation_rate, double avg_fitness,
+                    int redraw_map)
+{
+#ifdef USE_MLV
+    int tx, ty;
+
+    if (!v->initialised) return;
+
+    if (redraw_map)
+    {
+        MLV_clear_window(MLV_COLOR_BLACK);
+        draw_country(v, towns, town_count);
+        draw_hospitals(v, best, towns, insee_to_idx);
+        MLV_draw_line(v->sidebar_x, 0, v->sidebar_x, v->height, MLV_COLOR_WHITE);
+    }
+
+    clear_sidebar(v);
+    tx = sidebar_text_x(v);
+    ty = v->padding;
+
+    MLV_draw_text(tx, ty, "Generation       : %d", MLV_COLOR_WHITE, generation);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Hopitaux         : %d", MLV_COLOR_WHITE,
+                  best->fitness.hospital_count);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "CHRU             : %d", MLV_COLOR_WHITE,
+                  best->fitness.uhc_count);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Habitants eloignes : %d", MLV_COLOR_WHITE,
+                  best->fitness.distant_resident_count);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "%% pop desert     : %.2f", MLV_COLOR_WHITE,
+                  best->fitness.distant_resident_percent);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Villes eloignees : %d", MLV_COLOR_WHITE,
+                  best->fitness.distant_town_count);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "%% communes desert: %.2f", MLV_COLOR_WHITE,
+                  best->fitness.distant_town_percent);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "FITNESS          : %.0f", MLV_COLOR_WHITE,
+                  best->fitness.fitness_score);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Taille population: %d", MLV_COLOR_WHITE,
+                  POPULATION_SIZE);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Fitness moyenne  : %.0f", MLV_COLOR_WHITE,
+                  avg_fitness);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Stagnation       : %d / %d", MLV_COLOR_WHITE,
+                  stagnation, stagnation_limit);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Mutation         : %.2f", MLV_COLOR_WHITE,
+                  mutation_rate);
+    MLV_actualise_window();
+#else
+    (void)v; (void)towns; (void)town_count; (void)best; (void)insee_to_idx;
+    (void)generation; (void)stagnation; (void)stagnation_limit;
+    (void)mutation_rate; (void)avg_fitness; (void)redraw_map;
+#endif
+}
+
+void map_draw_final(const MapView *v, const Town *towns, int town_count,
+                    const Individual *result, const int *insee_to_idx,
+                    const char *covered, int total_beds)
+{
+#ifdef USE_MLV
+    int tx, ty;
+
+    if (!v->initialised) return;
+
+    MLV_clear_window(MLV_COLOR_BLACK);
+    draw_country(v, towns, town_count);
+    if (covered) draw_deserts(v, towns, town_count, covered);
+    draw_hospitals(v, result, towns, insee_to_idx);
+    MLV_draw_line(v->sidebar_x, 0, v->sidebar_x, v->height, MLV_COLOR_WHITE);
+
+    tx = sidebar_text_x(v);
+    ty = v->padding;
+    MLV_draw_text(tx, ty, "Resultat final", MLV_COLOR_WHITE);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Hopitaux         : %d", MLV_COLOR_WHITE,
+                  result->fitness.hospital_count);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "CHRU             : %d", MLV_COLOR_WHITE,
+                  result->fitness.uhc_count);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Habitants eloignes : %d", MLV_COLOR_WHITE,
+                  result->fitness.distant_resident_count);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "%% pop desert     : %.2f", MLV_COLOR_WHITE,
+                  result->fitness.distant_resident_percent);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Villes eloignees : %d", MLV_COLOR_WHITE,
+                  result->fitness.distant_town_count);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "%% communes desert: %.2f", MLV_COLOR_WHITE,
+                  result->fitness.distant_town_percent);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "FITNESS          : %.0f", MLV_COLOR_WHITE,
+                  result->fitness.fitness_score);
+    ty += MAP_LINE_HEIGHT;
+    MLV_draw_text(tx, ty, "Lits totaux      : %d", MLV_COLOR_WHITE, total_beds);
+    ty += MAP_LINE_HEIGHT * 2;
+    MLV_draw_text(tx, ty, "Touche pour quitter...", MLV_COLOR_WHITE);
+    MLV_actualise_window();
+    MLV_wait_keyboard(NULL, NULL, NULL);
+#else
+    (void)v; (void)towns; (void)town_count; (void)result;
+    (void)insee_to_idx; (void)covered; (void)total_beds;
+#endif
 }

--- a/apps/panacee-genetics/src/presentation/map/map.h
+++ b/apps/panacee-genetics/src/presentation/map/map.h
@@ -10,6 +10,6 @@ typedef struct {
     double max_lon;
 } BoundingBox;
 
-BoundingBox getBoundingBox(Town *towns, int count);
+BoundingBox get_bounding_box(const Town *towns, int count);
 
 #endif

--- a/apps/panacee-genetics/src/presentation/map/map.h
+++ b/apps/panacee-genetics/src/presentation/map/map.h
@@ -1,6 +1,7 @@
 #ifndef MAP_H
 #define MAP_H
 
+#include "../../domain/individual/individual.h"
 #include "../../domain/town/town.h"
 
 typedef struct {
@@ -11,5 +12,36 @@ typedef struct {
 } BoundingBox;
 
 BoundingBox get_bounding_box(const Town *towns, int count);
+
+#define MAP_SIDEBAR_WIDTH 300
+#define MAP_LINE_HEIGHT    30
+
+typedef struct {
+    int        padding;
+    int        height;
+    int        map_width;
+    int        sidebar_x;
+    int        sidebar_w;
+    BoundingBox box;
+    double     ratio;
+    double     cos_lat;
+    int        initialised;
+} MapView;
+
+int  map_init(MapView *view, const Town *towns, int town_count);
+void map_close(MapView *view);
+
+void map_draw_loading(const MapView *view, const Town *towns, int town_count,
+                      const char *message);
+
+void map_draw_state(const MapView *view, const Town *towns, int town_count,
+                    const Individual *best, const int *insee_to_idx,
+                    int generation, int stagnation, int stagnation_limit,
+                    double mutation_rate, double avg_fitness,
+                    int redraw_map);
+
+void map_draw_final(const MapView *view, const Town *towns, int town_count,
+                    const Individual *result, const int *insee_to_idx,
+                    const char *covered, int total_beds);
 
 #endif


### PR DESCRIPTION
## Résumé

Suite de patchs ciblés sur `apps/panacee-genetics/` :
- correctness (bugs latents dans le pipeline, pas dans la GA elle-même)
- propreté (extraction MLV dans la couche `presentation/`, suppression de code mort, renames)
- I/O (path CSV configurable, création des dossiers de sortie)
- reproductibilité (`PANACEE_SEED`)

Aucun changement de comportement de l'algorithme génétique : crossover, mutate, sélection greedy et local search restent identiques au `main`.

## Commits

`fix(genetics): rename PENALITY→PENALTY and TRESHOLD→THRESHOLD typos`
Renomme deux constantes mal orthographiées (`PENALITY_HOSPITAL` → `PENALTY_HOSPITAL`, `TRESHOLD_UHC` → `THRESHOLD_UHC`) dans `genetic.h` et tous les call-sites.

`fix(genetics): replace magic 100000 with INSEE_MAX constant`
Définit `INSEE_MAX` dans `genetic.h`, remplace les `100000` magiques dans `genetic.c` (table `insee_to_idx`) et `individual.c` (bitmap `present` du crossover). Ajoute aussi un bounds-check au moment de remplir la table.

`refactor(individual): drop unused math.h include`
Retire `#include <math.h>` de `individual.c` qui n'utilise aucune fonction math directement.

`fix(town): avoid malloc(0)+memcpy(NULL) in precompute_coverage`
Quand une ville n'a aucun voisin dans le rayon, on stocke `NULL` au lieu d'appeler `malloc(0)` (implementation-defined) puis `memcpy(NULL, ..., 0)` (UB).

`fix(genetics): re-evaluate fitness after local search`
La local search ajoute des hôpitaux à `result` mais ne met pas à jour `result.fitness`. Conséquence : le rapport final, le panel MLV et le CSV exporté affichaient le fitness pré-local-search. Ajoute un `evaluate(&result, ...)` avant `compute_beds()` et les exports.

`fix(main): guard parser failure and free GA result + town buffer`
Si `parse()` retourne `NULL` (CSV introuvable), `main` sortait en déréférencant un pointeur invalide. Ajoute un guard explicite + libère `result.hospitals` et `towns` en sortie pour rendre Valgrind silencieux.

`refactor(presentation): drop dead Color struct, snake_case bounding box`
Supprime le `typedef struct { int red, green, blue; } Color;` jamais utilisé dans `color.h`. Renomme `getBoundingBox` → `get_bounding_box` (cohérence snake_case avec le reste du code) et passe son argument en `const Town *`. Ajoute aussi `PANACEE_COLOR_RED` qui sert au commit MLV plus loin.

`fix(genetics): guard MLV init against degenerate bounding box / desktop size`
Sur un dataset dégénéré (une seule ville, ou bbox plate) le calcul de `mlv_ratio` divisait par zéro et castait `inf` en `int` (UB). Ajoute des fallbacks (carré 1:1) + un plancher de 600 px sur la hauteur de fenêtre + un plancher de 4 px sur le padding.

`refactor(presentation): move MLV drawing out of genetic.c into presentation/map`
Le bloc de dessin MLV (~150 lignes dupliquées trois fois dans `genetic.c`) est extrait dans `presentation/map/`. Introduit une struct `MapView` qui encapsule la projection + l'état de la fenêtre, et cinq fonctions : `map_init`/`map_close`/`map_draw_loading`/`map_draw_state`/`map_draw_final`. Quand `USE_MLV` n'est pas défini, toutes ces fonctions sont des no-ops, donc `genetic.c` n'a plus aucun `#ifdef USE_MLV`. Le panel final affiche aussi les villes "désert" en rouge (overlay optionnel).

`refactor(domain): make Town parameters const where the function only reads`
Passage en `const Town *` partout où `Town *` était écrit alors que la fonction ne mute jamais le pointeur : `evaluate`, `mutate`, `compute_beds`, `create_individual_*`, `run_genetic`, `init_population`, `evaluate_population`, `inhabitant_count`, `precompute_coverage`, exporters.

`fix(parser): accept CSV path via argv/env, warn on long rows`
`parse()` accepte maintenant un argument `path` (NULL → fallback `PANACEE_CSV_PATH` env, puis défaut historique). `main` forwarde `argv[1]`. `count_lines` détecte les lignes > 1023 octets et émet un warning au lieu de les compter en plusieurs lignes. `strtok` splitte aussi sur `\n` pour que la dernière colonne ne traîne pas un saut de ligne dans `atof`.

`fix(exporter): mkdir -p the output path's parent directory before opening`
Avant : si `./src/results/` n'existait pas, les trois `fopen("w")` échouaient silencieusement et le programme "réussissait" sans produire de CSV. Maintenant : helper `open_for_write` qui crée récursivement le dossier parent et reporte un `strerror(errno)` propre si `fopen` échoue quand même.

`refactor: name the 1e18 distance sentinel INFINITY_KM`
Le sentinel `1e18` utilisé dans `compute_beds` et l'export `towns_status` devient `INFINITY_KM`, défini une seule fois dans `genetic.h`.

`fix(genetics): reproducible seed via PANACEE_SEED, throttled progress logs`
La variable `PANACEE_SEED` permet de fixer le seed RNG (deux runs identiques sur le même dataset → mêmes CSV exportés). Le seed effectif est imprimé au démarrage. La ligne `Gen NNNN | fitness: ...` est désormais affichée tous les `PROGRESS_INTERVAL` (= 25) générations ou à chaque amélioration, au lieu d'inonder stdout 200 000 fois.

`refactor(town): drop unused TOWN_COUNT constant`
Le `#define TOWN_COUNT 34437` dans `town.h` n'était référencé nulle part — la taille réelle vient toujours du parser.

`build(make): mkdir results`
La règle `$(RESULTS_DIR)` (= `src/results`) crée le dossier de sortie au besoin ; les targets `run` et `run-no-mlv` en dépendent. Première exécution sur un repo fraîchement cloné ne perd plus les CSV silencieusement (couplé au commit `fix(exporter)` plus haut).

`refactor(town): extract nearest_hospital_per_town helper`
`compute_beds` (dans `individual.c`) et `export_towns_status_csv` (dans `exporter.c`) calculaient la même chose : "pour chaque ville, l'hôpital le plus proche parmi ceux qui la couvrent". Extrait dans `town.c` comme `nearest_hospital_per_town`. Le buffer de distances est optionnel (NULL → scratch interne).

## Test plan

- [x] `make fclean && make no-mlv` clean sous `-Wall -ansi`
- [x] `PANACEE_SEED=42 ./panacee-no-mlv` tourne jusqu'au stagnation limit, exporte les trois CSV
- [x] Deux runs avec le même seed produisent les mêmes `hospitals.csv` / `fitness.csv`
- [ ] `make` (build MLV complet) sur une machine où `libMLV` est installée